### PR TITLE
Add CustomLogger for error message from SoftDebuggerAdaptor. Fixes #45

### DIFF
--- a/UnityDebug/Program.cs
+++ b/UnityDebug/Program.cs
@@ -27,6 +27,24 @@ namespace UnityDebug
 
 		};
 
+		class CustomLogger : Mono.Debugging.Client.ICustomLogger
+		{
+			public void LogAndShowException(string message, Exception ex)
+			{
+				LogError(message, ex);
+			}
+
+			public void LogError(string message, Exception ex)
+			{
+				Log.Write(message + (ex != null ? System.Environment.NewLine + ex.ToString() : string.Empty));
+			}
+
+			public void LogMessage(string messageFormat, params object[] args)
+			{
+				Log.Write(String.Format(messageFormat, args));
+			}
+		}
+
 		static void Main(string[] argv)
 		{
 			if(argv.Length > 0 && argv[0] == "list")
@@ -52,6 +70,7 @@ namespace UnityDebug
 		private static void RunSession(Stream inputStream, Stream outputStream)
 		{
 			DebugSession debugSession = new UnityDebugSession();
+			Mono.Debugging.Client.DebuggerLoggingService.CustomLogger = new CustomLogger();
 			debugSession.Start(inputStream, outputStream).Wait();
 		}
 


### PR DESCRIPTION
I found that the broken error message causing #45 is from SoftDebuggerAdaptor.
(MonoDebug/sdb/dep/debugger-libs/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs#L2121)

This message is given to Console.WriteLine() because CustomLogger is not set.
(MonoDebug/sdb/dep/debugger-libs/Mono.Debugging/Mono.Debugging.Client/DebuggerLoggingService.cs#L44)

This patch adds CustomLogger which write the message to log-file by using UnityDebug.Log.

Finally, I got original error message including Japanese character from UnityDebug-log.txt, and debugger no longer abort by unexpected message.

~~~
04:07:17.840218: Error in soft debugger method call thread on method DateTime System.DateTime:get_Now () on object System.DateTime
System.ArgumentException: Incorrect number or types of arguments
パラメーター名:arguments
   場所 Mono.Debugger.Soft.ObjectMirror.EndInvokeMethodInternalWithResult(IAsyncResult asyncResult)
   場所 Mono.Debugger.Soft.StructMirror.EndInvokeMethodWithResult(IAsyncResult asyncResult)
   場所 Mono.Debugging.Soft.MethodCall.EndInvoke()
~~~
(In English, "パラメーター名" is 'Parameter name' and "場所" is 'place' (or 'location'?)