### PR TITLE
Fix for not seeing values of local variables on .NET 4.6+

### DIFF
--- a/UnityDebug/UnityDebugSession.cs
+++ b/UnityDebug/UnityDebugSession.cs
@@ -488,6 +488,12 @@ namespace UnityDebug
 							}
 						}
 						else if (flags.HasFlag(ObjectValueFlags.Object) && flags.HasFlag(ObjectValueFlags.Namespace)) {
+							// fix for not seeing fields in .NET 4.6+
+							if (!expression.StartsWith("this", System.StringComparison.Ordinal)) {
+								args["expression"] = "this." + expression;
+								Evaluate(response, args);
+								return;
+							}
 							error = "not available";
 						}
 						else {


### PR DESCRIPTION
Previously hovering over local variables didn't work unless you added "this." before the member.
I've only noticed this in the newer .NET runtime.
This workaround is essentially the same as the previous.

This should fix #62 