### PR TITLE
Fixed "Load More Stack Frames" loading the wrong set of frames.

### DIFF
--- a/UnityDebug/UnityDebugSession.cs
+++ b/UnityDebug/UnityDebugSession.cs
@@ -630,6 +630,7 @@ namespace UnityDebug
         {
             Log.Write($"UnityDebug: StackTrace: {response} ; {arguments}");
             int maxLevels = GetInt(arguments, "levels", 10);
+            int startFrame = GetInt(arguments, "startFrame", 0);
             int threadReference = GetInt(arguments, "threadId", 0);
 
             WaitForSuspend();
@@ -653,7 +654,7 @@ namespace UnityDebug
             {
                 totalFrames = bt.FrameCount;
 
-                for (var i = 0; i < Math.Min(totalFrames, maxLevels); i++)
+                for (var i = startFrame; i < Math.Min(totalFrames, startFrame + maxLevels); i++)
                 {
                     var frame = bt.GetFrame(i);
 


### PR DESCRIPTION
When you break and the "Load More Stack Frames" button is visible, instead of loading more, it actually loads the same set of frames that are already loaded and appends them to the list.

When we get a request to load more frames, there's a `startFrame` property in the arguments which was previously ignored. Offsetting the index into the backtrace by `startFrame` seems to fix the issue for me, and it seems to be in line with the debug protocol docs I'm looking at. This isn't my area of expertise though!