### PR TITLE
Fix for evaluating variables in stack frames other than the top one

### DIFF
--- a/UnityDebug/UnityDebugSession.cs
+++ b/UnityDebug/UnityDebugSession.cs
@@ -800,6 +800,7 @@ namespace UnityDebug
         public override void Evaluate(Response response, dynamic args)
         {
             var expression = GetString(args, "expression");
+            var frameId = GetInt(args, "frameId", 0);
 
             if (expression == null)
             {
@@ -807,13 +808,14 @@ namespace UnityDebug
                 return;
             }
 
-            if (Frame == null)
+            var frame = m_FrameHandles.Get(frameId, null);
+            if (frame == null)
             {
                 SendError(response, "no active stackframe");
                 return;
             }
 
-            if (!Frame.ValidateExpression(expression))
+            if (!frame.ValidateExpression(expression))
             {
                 SendError(response, "invalid expression");
                 return;
@@ -822,7 +824,7 @@ namespace UnityDebug
             var evaluationOptions = m_DebuggerSessionOptions.EvaluationOptions.Clone();
             evaluationOptions.EllipsizeStrings = false;
             evaluationOptions.AllowMethodEvaluation = true;
-            var val = Frame.GetExpressionValue(expression, evaluationOptions);
+            var val = frame.GetExpressionValue(expression, evaluationOptions);
             val.WaitHandle.WaitOne();
 
             var flags = val.Flags;


### PR DESCRIPTION
The VS debugger protocol sends us `frameId`, which is the number of the stack frame the user has selected in the call stack window. At the moment we always evaluate expressions using the top frame, ignoring `frameId`, so if you click a lower frame, evaluating variables doesn't work properly. This commit makes Evaluate use the selected frame instead.