### PR TITLE
Use relative path to locate EditorInstance.json

### DIFF
--- a/typescript/attach.ts
+++ b/typescript/attach.ts
@@ -44,7 +44,7 @@ class UnityDebugConfigurationProvider implements DebugConfigurationProvider {
 			{
 				name: "Unity Editor",
 				type: "unity",
-				path: folder.uri.path + "/Library/EditorInstance.json",
+				path: "${workspaceFolder}/Library/EditorInstance.json",
 				request: "launch"
 			},
 			{


### PR DESCRIPTION
This fulfills the issue marked as an enhancement in #118.

This breaks any workspaces that don't have the Unity project directory as the workspace folder, but given that the default Unity workflow expects such, I'd imagine that's OK.