### PR TITLE
Activate only when looking for debuggers or invoking relevant commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "activationEvents": [
-    "*"
+    "onDebugInitialConfigurations",
+    "onDebugResolve:unity"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
This begins to address #142.

My attempts to implement activation events only when the `attach.attachToDebugger` command is run did not work. VS Code reported that the command did not exist presumably because the code to register the command doesn't run until the extension is activated.

If this is something that other debuggers like the Chrome or Java debugger, as mentioned in the issue, can support, then I'd like to look at implementing this as well. The full set of activation events that the extension can subscribe to are on [this documentation page](https://code.visualstudio.com/api/references/activation-events). It may be simple enough to add a check for the `editorInstance.json` file.

I'm not very familiar with VS Code extension development though, so any help on this is appreciated. In the meantime, I'm marking this as a draft PR.