### PR TITLE
More proper way to specify breakpoints contribution in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
     "*"
   ],
   "contributes": {
+    "breakpoints": [
+      {
+        "language": "csharp"
+      }
+    ],
     "commands": [
       {
         "command": "attach.attachToDebugger",
@@ -103,11 +108,6 @@
       {
         "type": "unity",
         "label": "Unity Debugger",
-        "enableBreakpointsFor": {
-          "languageIds": [
-            "csharp"
-          ]
-        },
         "program": "./bin/UnityDebug.exe",
         "osx": {
           "runtime": "mono"


### PR DESCRIPTION
Saw a warning in package.json that `enableBreakpointsFor` is not allowed. Found here example of more correct config:
https://github.com/microsoft/vscode-java-debug/blob/master/package.json