### PR TITLE
Fix UnityDebug.Tests.TestApp compilation

### DIFF
--- a/Tests/UnityDebug.Tests.TestApp/UnityDebug.Tests.TestApp.csproj
+++ b/Tests/UnityDebug.Tests.TestApp/UnityDebug.Tests.TestApp.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="..\..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.12.0\build\NUnit.props')" />
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -10,9 +11,9 @@
         <AppDesignerFolder>Properties</AppDesignerFolder>
         <RootNamespace>TestApp</RootNamespace>
         <AssemblyName>TestApp</AssemblyName>
-        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
         <FileAlignment>512</FileAlignment>
-        <FrameworkPathOverride>C:\projects\mono\mono\build\builds\monodistribution\lib\mono\4.5</FrameworkPathOverride>
+<!--        <FrameworkPathOverride>C:\projects\mono\mono\build\builds\monodistribution\lib\mono\4.5</FrameworkPathOverride>-->
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <PlatformTarget>AnyCPU</PlatformTarget>
@@ -34,21 +35,15 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-            <HintPath>..\..\mono\mono\build\builds\monodistribution\lib\mono\4.5\Microsoft.CSharp.dll</HintPath>
+        <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
+            <HintPath>..\..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
+            <Private>True</Private>
         </Reference>
-        <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
-            <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-        </Reference>
-        <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <HintPath>..\..\mono\mono\build\builds\monodistribution\lib\mono\4.5\System.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <HintPath>..\..\mono\mono\build\builds\monodistribution\lib\mono\4.5\System.Core.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <HintPath>..\..\mono\mono\build\builds\monodistribution\lib\mono\4.5\System.Xml.dll</HintPath>
-        </Reference>
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Xml" />
+        <Reference Include="Microsoft.CSharp.dll" />
     </ItemGroup>
     <ItemGroup>
         <Compile Include="AdvancedEvaluation.cs"/>


### PR DESCRIPTION
I took a part from `UnityDebug.Tests.csproj`. Actually I didn't run any tests yet, just fix compilation of TestApp, so whole solution could be built now without errors.

Also, I didn't actually understand the purpose of 
```
<FrameworkPathOverride>C:\projects\mono\mono\build\builds\monodistribution\lib\mono\4.5</FrameworkPathOverride>
```
so just comment it without fully removing.

Upd. I think I misunderstood workflow with tests. DebugTests.cs directly refers to `mono.exe` in the same location

https://github.com/Unity-Technologies/vscode-unity-debug/blob/d23a3cbdfb31d0a22be17949e9e9e7be66cfadce/Tests/UnityDebug.Tests/DebugTests.cs#L155


@miniwolf Could you please guide me on how it is expected to run tests?