### PR TITLE
Activate extension only on specific events

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,12 @@
     "watch": "tsc -w -p ./src/typescript"
   },
   "activationEvents": [
-    "*"
+    "onCommand:attach.attachToDebugger",
+    "onCommand:exceptions.addEntry",
+    "onCommand:exceptions.always",
+    "onCommand:exceptions.never",
+    "onView:exceptions",
+    "onDebug"
   ],
   "contributes": {
     "breakpoints": [


### PR DESCRIPTION
That is better version of https://github.com/Unity-Technologies/vscode-unity-debug/pull/175/commits/75a2dac4e6809c08f53bf8e22ddbc93997dea597

`onDebug` is almost same as `onDebugInitialConfigurations` and `onDebugResolve:unity`
https://code.visualstudio.com/api/references/activation-events#onDebug

Also I included all contributed commands and exceptions view